### PR TITLE
Ensure we are Monitoring Instance Memory

### DIFF
--- a/playbooks/frontend.yml
+++ b/playbooks/frontend.yml
@@ -1,7 +1,8 @@
 ---
 - hosts: frontend:frontend_staging
   vars:
-    scripts_dir: /home/ec2-user/scripts
+    user_scripts_dir: /home/ec2-user/scripts
+    monitoring_scripts_dir: "{{ user_scripts_dir }}/aws-scripts-mon"
   become: yes
   become_method: sudo
   remote_user: ec2-user
@@ -25,11 +26,11 @@
         - unzip
         - curl
 
-    - stat: path={{ scripts_dir }}
-      register: scripts_dir_check
+    - stat: "path={{ monitoring_scripts_dir }}"
+      register: monitoring_scripts_dir_check
 
     - name: Setup Amazon CloudWatch Memory Monitoring Script
       import_tasks: '../tasks/cloudwatch_memory_monitoring.yml'
       vars:
-        user_scripts_dir: "{{ scripts_dir }}"
-      when: scripts_dir_check.stat.exists == False
+        scripts_dir: "{{ monitoring_scripts_dir }}"
+      when: monitoring_scripts_dir_check.stat.exists == False

--- a/playbooks/frontend.yml
+++ b/playbooks/frontend.yml
@@ -1,6 +1,7 @@
 ---
-
 - hosts: frontend:frontend_staging
+  vars:
+    scripts_dir: /home/ec2-user/scripts
   become: yes
   become_method: sudo
   remote_user: ec2-user
@@ -23,3 +24,12 @@
         - perl-XML-LibXML
         - unzip
         - curl
+
+    - stat: path={{ scripts_dir }}
+      register: scripts_dir_check
+
+    - name: Setup Amazon CloudWatch Memory Monitoring Script
+      import_tasks: '../tasks/cloudwatch_memory_monitoring.yml'
+      vars:
+        user_scripts_dir: "{{ scripts_dir }}"
+      when: scripts_dir_check.stat.exists == False

--- a/tasks/cloudwatch_memory_monitoring.yml
+++ b/tasks/cloudwatch_memory_monitoring.yml
@@ -5,7 +5,7 @@
     state: directory
 
 - name: Download Amazon CloudWatch Monitoring Scripts
-  get_url: url=http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip dest={{ user_scripts_dir }}/CloudWatchMonitoringScripts-1.2.2.zip
+  get_url: url=https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip dest={{ user_scripts_dir }}/CloudWatchMonitoringScripts-1.2.2.zip
 
 - name: Unarchive zip
   unarchive:

--- a/tasks/cloudwatch_memory_monitoring.yml
+++ b/tasks/cloudwatch_memory_monitoring.yml
@@ -1,17 +1,17 @@
 ---
 
 - file:
-    path: "{{ user_scripts_dir }}"
+    path: "{{ scripts_dir }}"
     state: directory
 
 - name: Download Amazon CloudWatch Monitoring Scripts
-  get_url: url=https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip dest={{ user_scripts_dir }}/CloudWatchMonitoringScripts-1.2.2.zip
+  get_url: url=https://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip dest={{ scripts_dir }}/CloudWatchMonitoringScripts-1.2.2.zip
 
 - name: Unarchive zip
   unarchive:
-    src: "{{ user_scripts_dir  }}/CloudWatchMonitoringScripts-1.2.2.zip"
-    dest: "{{ user_scripts_dir  }}"
+    src: "{{ scripts_dir  }}/CloudWatchMonitoringScripts-1.2.2.zip"
+    dest: "{{ scripts_dir  }}"
     remote_src: True
 
 - name: Delete zip file
-  file: path={{ user_scripts_dir }}/CloudWatchMonitoringScripts-1.2.2.zip state=absent
+  file: path={{ scripts_dir }}/CloudWatchMonitoringScripts-1.2.2.zip state=absent

--- a/tasks/cloudwatch_memory_monitoring.yml
+++ b/tasks/cloudwatch_memory_monitoring.yml
@@ -1,0 +1,17 @@
+---
+
+- file:
+    path: "{{ user_scripts_dir }}"
+    state: directory
+
+- name: Download Amazon CloudWatch Monitoring Scripts
+  get_url: url=http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip dest={{ user_scripts_dir }}/CloudWatchMonitoringScripts-1.2.2.zip
+
+- name: Unarchive zip
+  unarchive:
+    src: "{{ user_scripts_dir  }}/CloudWatchMonitoringScripts-1.2.2.zip"
+    dest: "{{ user_scripts_dir  }}"
+    remote_src: True
+
+- name: Delete zip file
+  file: path={{ user_scripts_dir }}/CloudWatchMonitoringScripts-1.2.2.zip state=absent


### PR DESCRIPTION
Cloudwatch doesn't monitor instance memory by default.
We need to pull in a custom script and add it to a cron (which will come
in a future PR). Ensure that this is present in the /scripts directory
for now.