### PR TITLE
Ensure a crontab entry exists for reporting memory metrics

### DIFF
--- a/playbooks/frontend.yml
+++ b/playbooks/frontend.yml
@@ -32,5 +32,14 @@
     - name: Setup Amazon CloudWatch Memory Monitoring Script
       import_tasks: '../tasks/cloudwatch_memory_monitoring.yml'
       vars:
-        scripts_dir: "{{ monitoring_scripts_dir }}"
+        scripts_dir: "{{ user_scripts_dir }}"
       when: monitoring_scripts_dir_check.stat.exists == False
+
+    - cron:
+        name: Report Memory Metrics
+        cron_file: /etc/crontab
+        minute: "*"
+        hour: "*"
+        day: "*"
+        user: root
+        job: "{{ monitoring_scripts_dir }}/mon-put-instance-data.pl --mem-used --from-cron --mem-avail --swap-used --mem-used-incl-cache-buff"


### PR DESCRIPTION
Also fix scripts directory where the monitoring scripts will live.
Sadly Ansible isn't clever enough to realise that this cron entry
already exists since it can only identify entries that it created.
These existing duplicate entries will have to be removed manually.