### PR TITLE
We have a daily cron to run security updates

### DIFF
--- a/inventory
+++ b/inventory
@@ -1,2 +1,5 @@
 [frontend_staging]
 xx.xx.xx.xx
+
+[frontend]
+xx.xx.xx.xx

--- a/playbooks/frontend.yml
+++ b/playbooks/frontend.yml
@@ -43,3 +43,20 @@
         day: "*"
         user: root
         job: "{{ monitoring_scripts_dir }}/mon-put-instance-data.pl --mem-used --from-cron --mem-avail --swap-used --mem-used-incl-cache-buff"
+
+    - name: Create security-updates script for cron.daily
+      copy:
+        src: ./scripts/security-updates
+        dest: /etc/cron.daily
+        owner: root
+        group: root
+        mode: 0755
+
+    - cron:
+        name: Run Daily Cron
+        cron_file: /etc/crontab
+        minute: "12"
+        hour: "{{ groups['frontend'].index(inventory_hostname) + 2 }}"
+        day: "*"
+        user: root
+        job: "run-parts /etc/cron.daily"

--- a/playbooks/scripts/security-updates
+++ b/playbooks/scripts/security-updates
@@ -1,0 +1,9 @@
+#!/bin/bash
+sudo yum update -y --security
+sudo yum update -y ecs-init
+sudo service docker restart
+sleep 5
+sudo start ecs
+# Forcefully restart the instance if the docker daemon has failed to restart
+# see https://github.com/docker/docker/issues/25382
+docker ps || sudo reboot


### PR DESCRIPTION
Ensure the security-updates script is in the cron.daily directory
and register it with crontab.

It loops through the node indexes to stagger restarts, so they don't all
happen at once.