### PR TITLE
Ensure instance is registered with the ECS cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ check-env:
 	$(if ${INVENTORY},,$(error Please specify your target environment))
 
 staging-london-frontend:
+	$(eval export ANSIBLE_ENV=staging)
 	$(eval export INVENTORY=frontend_staging)
 	$(eval export AWS_REGION=eu-west-2)
 
 staging-dublin-frontend:
+	$(eval export ANSIBLE_ENV=staging) # for production this will be wifi
 	$(eval export INVENTORY=frontend_staging)
 	$(eval export AWS_REGION=eu-west-1)
 

--- a/playbooks/frontend.yml
+++ b/playbooks/frontend.yml
@@ -73,3 +73,14 @@
         - mohamedh
         - ryanmacg
         - zahids
+
+    - name: Ensure /etc/ecs directory exists
+      file: path=/etc/ecs state=directory
+
+    - name: ECS Cluster Registration
+      copy:
+        dest: /etc/ecs/ecs.config
+        content: "ECS_CLUSTER={{ lookup('env', 'ANSIBLE_ENV') }}-frontend-cluster"
+        owner: root
+        group: root
+        mode: 0644


### PR DESCRIPTION
Make sure the /etc/ecs directory exists before populating the config
file pointing to one of the frontend clusters of either staging or wifi