### PR TITLE
Crontab environment variables and cron.hourly

### DIFF
--- a/playbooks/frontend.yml
+++ b/playbooks/frontend.yml
@@ -73,6 +73,15 @@
         mode: 0755
 
     - cron:
+        name: Run Hourly Cron
+        cron_file: /etc/crontab
+        minute: "42"
+        hour: "*"
+        day: "*"
+        user: root
+        job: "run-parts /etc/cron.hourly"
+
+    - cron:
         name: Run Daily Cron
         cron_file: /etc/crontab
         minute: "12"

--- a/playbooks/frontend.yml
+++ b/playbooks/frontend.yml
@@ -39,6 +39,22 @@
         scripts_dir: "{{ user_scripts_dir }}"
       when: monitoring_scripts_dir_check.stat.exists == False
 
+    - cronvar:
+        name: SHELL
+        value: /bin/bash
+
+    - cronvar:
+        name: PATH
+        value: /sbin:/bin:/usr/sbin:/usr/bin
+
+    - cronvar:
+        name: MAILTO
+        value: root
+
+    - cronvar:
+        name: HOME
+        value: /
+
     - cron:
         name: Report Memory Metrics
         cron_file: /etc/crontab


### PR DESCRIPTION
Ensure the correct environment variables are set for crontab, and make sure cron.hourly is managed by Ansible.