### PR TITLE
To iterate over instances in a region we need to know how many exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ check-env:
 
 staging-london-frontend:
 	$(eval export ANSIBLE_ENV=staging)
-	$(eval export INVENTORY=frontend_staging)
+	$(eval export INVENTORY=frontend_staging_london)
 	$(eval export AWS_REGION=eu-west-2)
 
 staging-dublin-frontend:
 	$(eval export ANSIBLE_ENV=staging) # for production this will be wifi
-	$(eval export INVENTORY=frontend_staging)
+	$(eval export INVENTORY=frontend_staging_dublin)
 	$(eval export AWS_REGION=eu-west-1)
 
 provision: check-env

--- a/inventory
+++ b/inventory
@@ -1,5 +1,8 @@
-[frontend_staging]
+[frontend_staging_dublin]
+xx.xx.xx.xx
+xx.xx.xx.xx
 xx.xx.xx.xx
 
-[frontend]
+[frontend_staging_london]
+xx.xx.xx.xx
 xx.xx.xx.xx

--- a/playbooks/frontend.yml
+++ b/playbooks/frontend.yml
@@ -1,10 +1,11 @@
 ---
-- hosts: frontend:frontend_staging
+- hosts: frontend_staging_london:frontend_staging_dublin
   vars:
     ansible_env: "{{ lookup('env', 'ANSIBLE_ENV') }}"
     user_scripts_dir: /home/ec2-user/scripts
     monitoring_scripts_dir: "{{ user_scripts_dir }}/aws-scripts-mon"
     aws_region: "{{ lookup('env', 'AWS_REGION') }}"
+    inventory: "{{ lookup('env', 'INVENTORY') }}"
 
   become: yes
   become_method: sudo
@@ -86,7 +87,7 @@
         name: Run Daily Cron
         cron_file: /etc/crontab
         minute: "12"
-        hour: "{{ groups['frontend'].index(inventory_hostname) + 2 }}"
+        hour: "{{ groups[inventory].index(inventory_hostname) + 2 }}"
         day: "*"
         user: root
         job: "run-parts /etc/cron.daily"


### PR DESCRIPTION
We iterate through all the nodes to work out the index and offset for
daily cron restarts.  Instead of duplicating inventory (which doesn't
work for multi region), just look up the current inventory.