### PR TITLE
Disable Anacron Daemon

### DIFF
--- a/playbooks/frontend.yml
+++ b/playbooks/frontend.yml
@@ -150,3 +150,8 @@
         name: '*'
         security: yes
         state: latest
+
+    - name: Ensure Anacron is disabled by making the binary non executable
+      file:
+        path: /usr/sbin/anacron
+        mode: 0644


### PR DESCRIPTION
Anacron is restarting all of our frontends each night at the same time.
This is undesirable and we have our own cron that does rolling restarts
on them.

By removing execute permissions on the anacron binary, it will disable
this.