### PR TITLE
Don't reboot the services over night

### DIFF
--- a/playbooks/scripts/security-updates
+++ b/playbooks/scripts/security-updates
@@ -1,9 +1,3 @@
 #!/bin/bash
 sudo yum update -y --security
 sudo yum update -y ecs-init
-sudo service docker restart
-sleep 5
-sudo start ecs
-# Forcefully restart the instance if the docker daemon has failed to restart
-# see https://github.com/docker/docker/issues/25382
-docker ps || sudo reboot


### PR DESCRIPTION
We have created a standalone app to do the restarts in a safe way.
We don't need this ECS restart to run as a cron anymore